### PR TITLE
Add initial shadows to render engines

### DIFF
--- a/resources/uber.frag.glsl
+++ b/resources/uber.frag.glsl
@@ -2,6 +2,7 @@
 
 in vec3 fragNor;
 in vec3 WPos;
+in vec4 shadowCoord;
 
 layout(location = 0) out vec4 color;
 
@@ -11,6 +12,8 @@ uniform vec3 MatAmb;
 uniform vec3 MatDif;
 
 uniform uint uberMode;
+uniform int shadowMode;
+uniform sampler2D depthTexture;
 
 // Used for Cook Torrance
 uniform float opacity;
@@ -88,5 +91,18 @@ void main() {
       color = vec4(Dcolor, 1.0);
 
 
+   }
+
+   if (shadowMode > 0) {
+       vec3 shift = shadowCoord.xyz * 0.5 + vec3(0.5);
+       color = vec4(shift.z, 0.0, 0.0, 1.0);
+   } else {
+        vec3 shift = shadowCoord.xyz * 0.5 + vec3(0.5);
+        float depth = texture(depthTexture, shift.xy).r;
+
+        float bias = 0.005;
+        if (depth < (shift.z - bias)) {
+           color = 0.5 * color;
+        }
    }
 }

--- a/resources/uber.vert.glsl
+++ b/resources/uber.vert.glsl
@@ -7,11 +7,24 @@ uniform mat4 P;
 uniform mat4 V;
 uniform mat4 M;
 
+uniform mat4 shadowP;
+uniform mat4 shadowV;
+uniform int shadowMode;
+
 out vec3 fragNor;
 out vec3 WPos;
+out vec4 shadowCoord;
 
 void main() {
-   gl_Position = P * V * M * vertPos;
+
+   if (shadowMode > 0) {
+       gl_Position = shadowP * shadowV * M * vertPos;
+   } else {
+       gl_Position = P * V * M * vertPos;
+   }
+
    fragNor = (V * M * vec4(vertNor, 0.0)).xyz;
    WPos = vec3(V * M * vertPos);
+
+   shadowCoord = shadowP * shadowV * M * vertPos;
 }

--- a/src/voyager-render/include/RenderEngine.h
+++ b/src/voyager-render/include/RenderEngine.h
@@ -53,12 +53,15 @@ protected:
    std::shared_ptr<Program> program;
    std::shared_ptr<WindowManager> window;
    std::shared_ptr<Hud> hud;
+   GLuint depthBufferId;
+   GLuint depthTextureId;
 
    virtual void render(std::shared_ptr<Renderable> renderable);
 
    // virtual void setMaterial(std::shared_ptr<Program> prog, glm::vec3 amb,
    //    glm::vec3 dif);
 
+   void initShadows();
 };
 
 #endif


### PR DESCRIPTION
This adds basic, blocky shadows to the render engine.
The cam / ortho position are fixed for right now but we will change that
so it grabs the size of the world from the terrain object.