### PR TITLE
Update Shadows for new World

### DIFF
--- a/resources/uber.frag.glsl
+++ b/resources/uber.frag.glsl
@@ -27,8 +27,9 @@ uniform sampler2D terrainTexture;
 uniform sampler2D terrainNormalMap;
 
 vec4 cookTorrance(vec3 normal) {
-   vec3 lightDirection = lightPos - WPos;
+   vec3 lightDirection = lightPos - wFragPos;
    float lightDistance = length(lightDirection);
+   lightDirection = normalize(lightDirection);
 
    // do the lighting calculation for each fragment
    float NdotL = max(dot(normal, lightDirection), 0.0);
@@ -135,7 +136,12 @@ void main() {
         vec3 shift = shadowCoord.xyz * 0.5 + vec3(0.5);
         float depth = texture(depthTexture, shift.xy).r;
 
-        float bias = 0.005;
+        vec3 lightDirection = normalize(lightPos - wFragPos);
+        float bias = 0.005 * tan(acos(dot(wFragNor,lightDirection)));
+        bias = clamp(bias, 0.005, 0.1);
+        if (shift.x > 1 || shift.x < 0) {
+            return;
+        }
         if (depth < (shift.z - bias)) {
            color = 0.5 * color;
         }

--- a/src/voyager-render/include/RenderEngine.h
+++ b/src/voyager-render/include/RenderEngine.h
@@ -66,6 +66,7 @@ protected:
    std::shared_ptr<Hud> hud;
    GLuint depthBufferId;
    GLuint depthTextureId;
+   int depthResolution;
 
    std::string terrainTextureFilename;
    std::shared_ptr<Texture> terrainTexture;


### PR DESCRIPTION
This updates the shadows to work in an arbitrary world. It grabs the
height from the terrain and uses this for the Near/Far planes. The X/Y
boundaries are centered around the player and offset by a constant
distance.

Along with this it adds the code for increasing bias on edges with
tangents perpindicular to the light and bumps up the resolution of the
shadow maps through an added constant.